### PR TITLE
EE-391: Add checks and errors around logic that checks dynamo respons…

### DIFF
--- a/action.js
+++ b/action.js
@@ -177,7 +177,15 @@ module.exports = class {
       })
     );
 
-    const jiraAccountIds = rigupReviewers.map((rev) => rev.Items[0].bitbucketId.S);
+    const jiraAccountIds = rigupReviewers.reduce((reviewers, record) => {
+      if(record.Items[0].bitbucketId) {
+        reviewers.push(record.Items[0].bitbucketId.S)
+      } else {
+        this.core.info(`Unknown Atlassian user ${record.Items[0].fullName.S}` )
+      }
+      return reviewers;
+    }, []);
+    
     const resp = await this.Jira.getUsersFromAccountIds(jiraAccountIds);
 
     if (resp && resp.data && resp.data.values) {
@@ -203,8 +211,16 @@ module.exports = class {
         return this.dynamo.findByGithubId(approver.id);
       })
     );
+    
+    const jiraAccountIds = rigupApprovers.reduce((approvers, record) => {
+      if(record.Items[0].bitbucketId) {
+        approvers.push(record.Items[0].bitbucketId.S)
+      } else {
+        this.core.info(`Unknown Atlassian user ${record.Items[0].fullName.S}` )
+      }
+      return approvers;
+    }, []);
 
-    const jiraAccountIds = rigupApprovers.map((rev) => rev.Items[0].bitbucketId.S);
     const resp = await this.Jira.getUsersFromAccountIds(jiraAccountIds);
 
     if (resp && resp.data && resp.data.values) {
@@ -228,7 +244,10 @@ module.exports = class {
     if (!rigupUser) {
       this.core.error(`PR by unknown user? - ${user}`);
     }
-
+    
+    if(!rigupUser.Items[0].bitbucketId) {
+      this.core.error("Unknown Atlassian user")
+    }
     const jiraAccountId = rigupUser.Items[0].bitbucketId.S;
     const resp = await this.Jira.getUsersFromAccountIds([jiraAccountId]);
 

--- a/action.js
+++ b/action.js
@@ -179,9 +179,9 @@ module.exports = class {
 
     const jiraAccountIds = rigupReviewers.reduce((reviewers, record) => {
       if(record.Items[0].bitbucketId) {
-        reviewers.push(record.Items[0].bitbucketId.S)
+        reviewers.push(record.Items[0].bitbucketId["S"])
       } else {
-        this.core.info(`Unknown Atlassian user ${record.Items[0].fullName.S}` )
+        this.core.info(`Unknown Atlassian user ${record.Items[0].fullName["S"]}` )
       }
       return reviewers;
     }, []);
@@ -214,7 +214,7 @@ module.exports = class {
     
     const jiraAccountIds = rigupApprovers.reduce((approvers, record) => {
       if(record.Items[0].bitbucketId) {
-        approvers.push(record.Items[0].bitbucketId.S)
+        approvers.push(record.Items[0].bitbucketId["S"])
       } else {
         this.core.info(`Unknown Atlassian user ${record.Items[0].fullName.S}` )
       }
@@ -248,7 +248,7 @@ module.exports = class {
     if(!rigupUser.Items[0].bitbucketId) {
       this.core.error("Unknown Atlassian user")
     }
-    const jiraAccountId = rigupUser.Items[0].bitbucketId.S;
+    const jiraAccountId = rigupUser.Items[0].bitbucketId["S"];
     const resp = await this.Jira.getUsersFromAccountIds([jiraAccountId]);
 
     if (resp && resp.data && resp.data.values) {


### PR DESCRIPTION
Tiny refactor to add error messaging around missing bitbucketId in dynamo response. We have seen this a few times over the last 2 days as new hires are joining and we removed the bitbucketId steps from ob boarding. @himichaelroberts is working on updating that column and its references to AtlassianId 