### PR TITLE
EE-859: add release platform parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ If false, will fail a GitHub Check if Validation fails, otherwise all checks wil
 
 Defaults to `"Task,Standalone Task,Bug"`
 
+`release-platform`
+
+(Optional) Value to set for Release Platform in JIRA.
+
 ## Outputs
 
 `verified`

--- a/action.js
+++ b/action.js
@@ -319,4 +319,12 @@ module.exports = class {
       this.core.info(`No Jira user for account id = ${jiraAccountId}`);
     }
   }
+
+  async setReleasePlatform(releasePlatform) {
+    if (!releasePlatform) {
+      return;
+    }
+
+    await this.Jira.setReleasePlatform(this.issue.key, releasePlatform);
+  }
 };

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "Allowed Issue Types, comma separated, can be 'Task,Standalone Task,Bug'"
     required: true
     default: "Task,Standalone Task,Bug"
+  release-platform: # id of input
+    description: "Release Platform in JIRA"
+    required: false
 outputs:
   verified: # id of output
     description: "Will be 'true' if it passed all checks, 'false' otherwise"

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const ROBOTS = ["dependabot[bot]", "dependabot-preview[bot]"];
 
     // `release-platform` input defined in action.yml
     const releasePlatform = core.getInput("release-platform");
-    core.debug(`Release Platform: ${releasePlatform}`);
+    core.info(`Release Platform: ${releasePlatform}`);
 
     const config = {
       baseUrl: process.env.JIRA_BASE_URL,

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ const ROBOTS = ["dependabot[bot]", "dependabot-preview[bot]"];
       `Allowed Issue Types - ${JSON.stringify(allowedIssueTypesInput)}`
     );
 
+    // `release-platform` input defined in action.yml
+    const releasePlatform = core.getInput("release-platform");
+    core.debug(`Release Platform: ${releasePlatform}`);
+
     const config = {
       baseUrl: process.env.JIRA_BASE_URL,
       token: process.env.JIRA_API_TOKEN,
@@ -61,6 +65,7 @@ const ROBOTS = ["dependabot[bot]", "dependabot-preview[bot]"];
       } else {
         await action.updateCodeReviewers();
         await action.autoAssignCreator();
+        await action.setReleasePlatform(releasePlatform);
       }
     }
 

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -78,6 +78,17 @@ module.exports = class {
     return this.instance(`/rest/api/3/issue/${issueId}/transitions`);
   }
 
+  async setReleasePlatform(issueId, releasePlatform) {
+    const customFieldId = 10189; // Release Platform
+
+    const fields = {};
+    fields[`customfield_${customFieldId}`] = { value: releasePlatform };
+    const data = {
+      fields,
+    };
+    return this.editIssue(issueId, data);
+  }
+
   async transitionIssue(issueId, data) {
     return this.instance.post(`/rest/api/3/issue/${issueId}/transitions`, {
       ...data,

--- a/test/lib/action.test.js
+++ b/test/lib/action.test.js
@@ -105,6 +105,24 @@ describe("Action Class Test", () => {
       sinon.assert.notCalled(jiraStub);
     });
 
+    it("setReleasePlatform() should return send req to Jira", async () => {
+      const jiraStub = sinon
+        .stub(jira, "setReleasePlatform")
+        .resolves({ status: 204 });
+
+      await action.setReleasePlatform('test123');
+      sinon.assert.calledOnce(jiraStub);
+    });
+
+    it("setReleasePlatform() skips empty release platform", async () => {
+      const jiraStub = sinon
+        .stub(jira, "setReleasePlatform")
+        .resolves({ status: 204 });
+
+      await action.setReleasePlatform('');
+      sinon.assert.notCalled(jiraStub);
+    });
+
     it("autoAssignCreator() should return send req to Jira", async () => {
       const jiraStub = sinon
         .stub(jira, "addAssigneeToIssue")

--- a/test/lib/jira.test.js
+++ b/test/lib/jira.test.js
@@ -76,4 +76,11 @@ describe('Jira Class Test', () => {
     const edit = await jira.addAssigneeToIssue('EE-299', users[0]);
     assert.notEqual(null, edit);
   });
+
+  it('setReleasePlatform should set release platform for an issue', async () => {
+    const accountIds = ['5be06148923d3245b8ba1a1f'];
+
+    const edit = await jira.setReleasePlatform('EE-859', 'other');
+    assert.notEqual(null, edit);
+  });
 });

--- a/test/recordings/Jira-Class-Test_4238035419/setReleasePlatform-should-set-release-platform-for-an-issue_588757927/recording.har
+++ b/test/recordings/Jira-Class-Test_4238035419/setReleasePlatform-should-set-release-platform-for-an-issue_588757927/recording.har
@@ -1,0 +1,147 @@
+{
+  "log": {
+    "_recordingName": "Jira Class Test/setReleasePlatform should set release platform for an issue",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "2.6.2"
+    },
+    "entries": [
+      {
+        "_id": "6226a6024086f005f98fca420f9ebf1d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 50,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": [
+                ""
+              ]
+            },
+            {
+              "name": "user-agent",
+              "value": "axios/0.19.0"
+            },
+            {
+              "name": "content-length",
+              "value": 50
+            },
+            {
+              "name": "host",
+              "value": "rigup.atlassian.net"
+            }
+          ],
+          "headersSize": 274,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"fields\":{\"customfield_10189\":{\"value\":\"other\"}}}"
+          },
+          "queryString": [],
+          "url": "https://rigup.atlassian.net/rest/api/3/issue/EE-859"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 0
+          },
+          "cookies": [
+            {
+              "name": "atlassian.xsrf.token",
+              "path": "/",
+              "secure": true,
+              "value": "6b9cd209-74ad-4c57-ad94-e4a5e73d4020_c1d099facd3b12ccce164109e8de270f4938d965_lin"
+            }
+          ],
+          "headers": [
+            {
+              "name": "server",
+              "value": "AtlassianProxy/1.15.8.1"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store, no-transform"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=315360000; includeSubDomains; preload"
+            },
+            {
+              "name": "date",
+              "value": "Sat, 14 Dec 2019 08:38:47 GMT"
+            },
+            {
+              "name": "atl-traceid",
+              "value": "68219017d797d0c1"
+            },
+            {
+              "name": "x-aaccountid",
+              "value": "557058%3A180fbfdf-265b-43c6-bf49-f1a57c2cb506"
+            },
+            {
+              "name": "x-arequestid",
+              "value": "9bf0e7fa-85c9-49f5-95bb-be5395b351ed"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "timing-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "atlassian.xsrf.token=6b9cd209-74ad-4c57-ad94-e4a5e73d4020_c1d099facd3b12ccce164109e8de270f4938d965_lin; Path=/; Secure"
+            }
+          ],
+          "headersSize": 626,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 204,
+          "statusText": "No Content"
+        },
+        "startedDateTime": "2019-12-14T08:38:47.126Z",
+        "time": 823,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 823
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
using release platform instead of platform app in anticipation of EE-639, but can change it to platform app if desired. 

will need to update every repo's jira workflow file.

example: 
https://github.com/rigup/logistics/pull/61/files
https://rigup.atlassian.net/browse/WM-434

I do have one concern that setting the release platform, code reviews, and creator don't really feel like "jira validation" steps, but I also didn't want to create a separate action ¯\\\_(ツ)_/¯ 

my current plan is to update every repo that has a known release platform, then make release-platform required and default to other, then remove the "rigup" default in jira and add a condition that doesn't allow a task to move to ready for deploy unless release platform is set.
as long as we can accurately determine the release platform, we can just use automation for jira to immediately move logistics, mobile, concert, etc tickets immediately to ready for deployment on transition to in verification (triggered merged to master), and use the concert deployment hook to move to deployed on successful deploy 